### PR TITLE
use relative path instead for referencing generated files

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
 import { Text, View, StyleSheet } from 'react-native';
-import { Keys } from 'nostr-sdk-react-native';
+import { Keys } from '../../src';
 
 const keys = Keys.generate();
 


### PR DESCRIPTION
nostr-sdk-react-native is not a module name so it does not work unless using relative path instead